### PR TITLE
Experimental support for 128px high displays

### DIFF
--- a/ssd1306/ssd1306.c
+++ b/ssd1306/ssd1306.c
@@ -111,8 +111,10 @@ void ssd1306_Init(void) {
     ssd1306_WriteCommand(0x1F); //
 #elif (SSD1306_HEIGHT == 64)
     ssd1306_WriteCommand(0x3F); //
+#elif (SSD1306_HEIGHT == 128)
+    ssd1306_WriteCommand(0x3F); // Seems to work for 128px high displays too.
 #else
-#error "Only 32 or 64 lines of height are supported!"
+#error "Only 32, 64, or 128 lines of height are supported!"
 #endif
 
     ssd1306_WriteCommand(0xA4); //0xa4,Output follows RAM content;0xa5,Output ignores RAM content
@@ -131,8 +133,10 @@ void ssd1306_Init(void) {
     ssd1306_WriteCommand(0x02);
 #elif (SSD1306_HEIGHT == 64)
     ssd1306_WriteCommand(0x12);
+#elif (SSD1306_HEIGHT == 128)
+    ssd1306_WriteCommand(0x12);
 #else
-#error "Only 32 or 64 lines of height are supported!"
+#error "Only 32, 64, or 128 lines of height are supported!"
 #endif
 
     ssd1306_WriteCommand(0xDB); //--set vcomh

--- a/ssd1306/ssd1306.c
+++ b/ssd1306/ssd1306.c
@@ -99,7 +99,14 @@ void ssd1306_Init(void) {
     ssd1306_WriteCommand(0xA6); //--set normal color
 #endif
 
+// Set multiplex ratio.
+#if (SSD1306_HEIGHT == 128)
+    // Found in the Luma Python lib for SH1106.
+    ssd1306_WriteCommand(0xFF);
+#else
     ssd1306_WriteCommand(0xA8); //--set multiplex ratio(1 to 64) - CHECK
+#endif
+
 #if (SSD1306_HEIGHT == 32)
     ssd1306_WriteCommand(0x1F); //
 #elif (SSD1306_HEIGHT == 64)

--- a/ssd1306/ssd1306.c
+++ b/ssd1306/ssd1306.c
@@ -171,9 +171,14 @@ void ssd1306_Fill(SSD1306_COLOR color) {
 
 // Write the screenbuffer with changed to the screen
 void ssd1306_UpdateScreen(void) {
-    uint8_t i;
-    for(i = 0; i < 8; i++) {
-        ssd1306_WriteCommand(0xB0 + i);
+    // Write data to each page of RAM. Number of pages
+    // depends on the screen height:
+    //
+    //  * 32px   ==  4 pages
+    //  * 64px   ==  8 pages
+    //  * 128px  ==  16 pages
+    for(uint8_t i = 0; i < SSD1306_HEIGHT/8; i++) {
+        ssd1306_WriteCommand(0xB0 + i); // Set the current RAM page address.
         ssd1306_WriteCommand(0x00);
         ssd1306_WriteCommand(0x10);
         ssd1306_WriteData(&SSD1306_Buffer[SSD1306_WIDTH*i],SSD1306_WIDTH);


### PR DESCRIPTION
This PR offers experimental support for 128px high displays as discussed
in issue #26. It:

* Adds `else` branches for `SSD1306_HEIGHT == 128` which send the
  same commands as 64px high displays. This seems to work on my
  [1.12" mono OLED](https://shop.pimoroni.com/products/1-12-oled-breakout?variant=12628508704851) using the `SH1106` driver. The
  error message has also been amended to mention support for 128px
  displays.
* Sets the correct multiplex ratio for 128px high displays. The value of
  `0xFF` was found in the [Luma Python library](https://github.com/rm-hull/luma.oled/blob/5ff5bf3730d733022019d0411927c8731147b07b/luma/oled/device/__init__.py#L78) for the `SH1106` driver.
* Modifies the `UpdateScreen` method so the number of RAM pages
  to iterate over is calculated dynamically based on the height. The
  SSD1306 datasheet advises 8 pages for a 64px display, so we need
  16 pages for 128px and 4 pages for 32px.

I've run through the test examples and everything seems to render
correctly on the 128x128px display I have. I would appreciate if someone
could test these changes on a 64px and 32px high display to ensure
it hasn't broken anything.

![IMG_4711](https://user-images.githubusercontent.com/4476568/77837731-2496b880-71b8-11ea-9657-b776e292c87b.jpg)
