### PR TITLE
Added define to set horizontal screen offset

### DIFF
--- a/ssd1306/ssd1306.c
+++ b/ssd1306/ssd1306.c
@@ -191,8 +191,8 @@ void ssd1306_UpdateScreen(void) {
     //  * 128px  ==  16 pages
     for(uint8_t i = 0; i < SSD1306_HEIGHT/8; i++) {
         ssd1306_WriteCommand(0xB0 + i); // Set the current RAM page address.
-        ssd1306_WriteCommand(0x00);
-        ssd1306_WriteCommand(0x10);
+        ssd1306_WriteCommand(0x00 + SSD1306_X_OFFSET_LOWER);
+        ssd1306_WriteCommand(0x10 + SSD1306_X_OFFSET_UPPER);
         ssd1306_WriteData(&SSD1306_Buffer[SSD1306_WIDTH*i],SSD1306_WIDTH);
     }
 }

--- a/ssd1306/ssd1306.h
+++ b/ssd1306/ssd1306.h
@@ -42,6 +42,14 @@ _BEGIN_STD_C
 #error "SSD1306 library was tested only on STM32F0, STM32F1, STM32F3, STM32F4, STM32F7, STM32L0, STM32L1, STM32L4, STM32H7, STM32G0, STM32G4 MCU families. Please modify ssd1306.h if you know what you are doing. Also please send a pull request if it turns out the library works on other MCU's as well!"
 #endif
 
+#ifdef SSD1306_X_OFFSET
+#define SSD1306_X_OFFSET_LOWER (SSD1306_X_OFFSET & 0x0F)
+#define SSD1306_X_OFFSET_UPPER ((SSD1306_X_OFFSET >> 4) & 0x07)
+#else
+#define SSD1306_X_OFFSET_LOWER 0
+#define SSD1306_X_OFFSET_UPPER 0
+#endif
+
 #include "ssd1306_fonts.h"
 
 /* vvv I2C config vvv */

--- a/ssd1306/ssd1306_conf_template.h
+++ b/ssd1306/ssd1306_conf_template.h
@@ -48,10 +48,14 @@
 #define SSD1306_INCLUDE_FONT_11x18
 #define SSD1306_INCLUDE_FONT_16x26
 
-// Some OLEDs don't display anything in first two columns.
-// In this case change the following macro to 130.
-// The default value is 128.
-// #define SSD1306_WIDTH           130
+// The width of the screen can be set using this
+// define. The default value is 128.
+// #define SSD1306_WIDTH           64
+
+// If your screen horizontal axis does not start
+// in column 0 you can use this define to
+// adjust the horizontal offset
+// #define SSD1306_X_OFFSET
 
 // The height can be changed as well if necessary.
 // It can be 32, 64 or 128. The default value is 64.


### PR DESCRIPTION
First of all, thanks for the library :)

I have been testing a small screen (64x48) which has a 32 pixel offset in X. As using a bigger buffer is inefficient and for I2C the transfer speed is not very high I have implemented a define to add an offset to the buffer writes, it uses the column start address command to apply it avoiding the need to send unneeded data.

Cheers.