### PR TITLE
feat: added "Invert" as a new color

### DIFF
--- a/ssd1306/ssd1306.c
+++ b/ssd1306/ssd1306.c
@@ -207,6 +207,18 @@ void ssd1306_DrawPixel(uint8_t x, uint8_t y, SSD1306_COLOR color) {
         return;
     }
    
+    // if inversion is choosen, check the current pixel color and invert it
+    if(color == Invert) {
+    	if((SSD1306_Buffer[x + (y / 8) * SSD1306_WIDTH] & (1 << (y % 8))) > 0)
+    	{
+    		color = Black;
+    	}
+    	else
+    	{
+    		color = White;
+    	}
+    }
+
     // Draw in the right color
     if(color == White) {
         SSD1306_Buffer[x + (y / 8) * SSD1306_WIDTH] |= 1 << (y % 8);
@@ -240,7 +252,7 @@ char ssd1306_WriteChar(char ch, FontDef Font, SSD1306_COLOR color) {
         for(j = 0; j < Font.FontWidth; j++) {
             if((b << j) & 0x8000)  {
                 ssd1306_DrawPixel(SSD1306.CurrentX + j, (SSD1306.CurrentY + i), (SSD1306_COLOR) color);
-            } else {
+            } else if(color != Invert){
                 ssd1306_DrawPixel(SSD1306.CurrentX + j, (SSD1306.CurrentY + i), (SSD1306_COLOR)!color);
             }
         }

--- a/ssd1306/ssd1306.h
+++ b/ssd1306/ssd1306.h
@@ -118,7 +118,8 @@ extern SPI_HandleTypeDef SSD1306_SPI_PORT;
 // Enumeration for screen colors
 typedef enum {
     Black = 0x00, // Black color, no pixel
-    White = 0x01  // Pixel is set. Color depends on OLED
+    White = 0x01,  // Pixel is set. Color depends on OLED
+	Invert = 0x02, // Color of the affected pixel will be inverted
 } SSD1306_COLOR;
 
 typedef enum {


### PR DESCRIPTION
The new color "Invert" can be useful when drawing texts and/or graphics over each other.
The color of each affected pixel in the buffer is inverted be the following written pixel.

For characters/strings this means, that there will not be a solid text background color when choosing "Invert" as color.

![IMG_20220713_223814](https://user-images.githubusercontent.com/33325587/178939127-7809e10e-cc6e-4059-a360-4e2c7e48c768.jpg)

![IMG_20220713_224701](https://user-images.githubusercontent.com/33325587/178939178-1e38a32a-7555-4ad0-ba3a-1b75280ca58b.jpg)
