### PR TITLE
[Fix bug] not display

### DIFF
--- a/ssd1306/ssd1306.c
+++ b/ssd1306/ssd1306.c
@@ -194,6 +194,7 @@ void ssd1306_UpdateScreen(void) {
         ssd1306_WriteCommand(0x10 + SSD1306_X_OFFSET_UPPER);
         ssd1306_WriteData(&SSD1306_Buffer[SSD1306_WIDTH*i],SSD1306_WIDTH);
     }
+    HAL_GPIO_WritePin(SSD1306_CS_Port, SSD1306_CS_Pin, GPIO_PIN_RESET); // Re-select the OLED after completing the write operation
 }
 
 /*

--- a/ssd1306/ssd1306.c
+++ b/ssd1306/ssd1306.c
@@ -194,8 +194,12 @@ void ssd1306_UpdateScreen(void) {
         ssd1306_WriteCommand(0x10 + SSD1306_X_OFFSET_UPPER);
         ssd1306_WriteData(&SSD1306_Buffer[SSD1306_WIDTH*i],SSD1306_WIDTH);
     }
-    HAL_GPIO_WritePin(SSD1306_CS_Port, SSD1306_CS_Pin, GPIO_PIN_RESET); // Re-select the OLED after completing the write operation
+#ifdef SSD1306_USE_SPI //For SPI
+    // Re-select the OLED after completing the write operation
+    HAL_GPIO_WritePin(SSD1306_CS_Port, SSD1306_CS_Pin, GPIO_PIN_RESET); 
+#endif
 }
+
 
 /*
  * Draw one pixel in the screenbuffer


### PR DESCRIPTION
Fixed the problem that the screen could not be lit when the cs pin was high (unselected state) after the update screen function was executed.