### PR TITLE
Minor fixes

### DIFF
--- a/ssd1306/ssd1306_tests.c
+++ b/ssd1306/ssd1306_tests.c
@@ -133,7 +133,7 @@ void ssd1306_TestBorder() {
     
         HAL_Delay(5);
         end = HAL_GetTick();
-    } while((end - start) < 8000);
+    } while((end - start) < 8000 || y > 0);
    
     HAL_Delay(1000);
 }

--- a/ssd1306/ssd1306_tests.c
+++ b/ssd1306/ssd1306_tests.c
@@ -119,9 +119,9 @@ void ssd1306_TestBorder() {
     do {
         ssd1306_DrawPixel(x, y, Black);
 
-        if((y == 0) && (x < 127))
+        if((y == 0) && (x < (SSD1306_WIDTH-1)))
             x++;
-        else if((x == 127) && (y < (SSD1306_HEIGHT-1)))
+        else if((x == (SSD1306_WIDTH-1)) && (y < (SSD1306_HEIGHT-1)))
             y++;
         else if((y == (SSD1306_HEIGHT-1)) && (x > 0)) 
             x--;

--- a/ssd1306/ssd1306_tests.h
+++ b/ssd1306/ssd1306_tests.h
@@ -6,7 +6,8 @@
 _BEGIN_STD_C
 
 void ssd1306_TestBorder(void);
-void ssd1306_TestFonts(void);
+void ssd1306_TestFonts1(void);
+void ssd1306_TestFonts2(void);
 void ssd1306_TestFPS(void);
 void ssd1306_TestAll(void);
 void ssd1306_TestLine(void);


### PR DESCRIPTION
fixed function names in ssd1306_fonts.h
use constants instead of magic numbers in ssd1306_TestBorder()