### PR TITLE
stop the Border Test after checking the entire perimeter of the screen

### DIFF
--- a/ssd1306/ssd1306_tests.c
+++ b/ssd1306/ssd1306_tests.c
@@ -112,8 +112,6 @@ const unsigned char github_logo_64x64[] = {
 void ssd1306_TestBorder() {
     ssd1306_Fill(Black);
    
-    uint32_t start = HAL_GetTick();
-    uint32_t end = start;
     uint8_t x = 0;
     uint8_t y = 0;
     do {
@@ -132,8 +130,7 @@ void ssd1306_TestBorder() {
         ssd1306_UpdateScreen();
     
         HAL_Delay(5);
-        end = HAL_GetTick();
-    } while((end - start) < 8000 || y > 0);
+    } while(x > 0 || y > 0);
    
     HAL_Delay(1000);
 }


### PR DESCRIPTION
Removed HAL_GetTick()

Default timeout in ssd1306_TestBorder() is not enough to check left side of display. After changes, test will stop when the pointer returns to its initial position (x=0, y=0)