### PR TITLE
Quickly tested on STM32L562CETx using I2C and seeed OLED display 1.12…

### DIFF
--- a/ssd1306/ssd1306.h
+++ b/ssd1306/ssd1306.h
@@ -28,6 +28,8 @@ _BEGIN_STD_C
 #include "stm32l1xx_hal.h"
 #elif defined(STM32L4)
 #include "stm32l4xx_hal.h"
+#elif defined(STM32L5)
+#include "stm32l5xx_hal.h"
 #elif defined(STM32F3)
 #include "stm32f3xx_hal.h"
 #elif defined(STM32H7)


### PR DESCRIPTION
Quickly tested on STM32L562CETx using I2C and seeed OLED display 1.12 V3.0 (SH1107). Dropped ssd1306_TestAll() in main loop and it worked like a charm.