### PR TITLE
fix always true condition in angle normalization

### DIFF
--- a/ssd1306/ssd1306.c
+++ b/ssd1306/ssd1306.c
@@ -325,7 +325,7 @@ static uint16_t ssd1306_NormalizeTo0_360(uint16_t par_deg) {
         loc_angle = par_deg;
     } else {
         loc_angle = par_deg % 360;
-        loc_angle = ((par_deg != 0)?par_deg:360);
+        loc_angle = (loc_angle ? loc_angle : 360);
     }
     return loc_angle;
 }


### PR DESCRIPTION
```c
/* Normalize degree to [0;360] */
static uint16_t ssd1306_NormalizeTo0_360(uint16_t par_deg) {
    uint16_t loc_angle;
    if(par_deg <= 360) {
        loc_angle = par_deg;
    } else {
        loc_angle = par_deg % 360;
        loc_angle = ((par_deg != 0)?par_deg:360); // <- always true condition here
    }
    return loc_angle;
}
```

It should be `loc_angle` instead