### PR TITLE
Support STM32C0

### DIFF
--- a/ssd1306/ssd1306.h
+++ b/ssd1306/ssd1306.h
@@ -44,8 +44,10 @@ _BEGIN_STD_C
 #include "stm32g0xx_hal.h"
 #elif defined(STM32G4)
 #include "stm32g4xx_hal.h"
+#elif defined(STM32C0)
+#include "stm32c0xx_hal.h"
 #else
-#error "SSD1306 library was tested only on STM32F0, STM32F1, STM32F3, STM32F4, STM32F7, STM32L0, STM32L1, STM32L4, STM32H7, STM32G0, STM32G4, STM32WB MCU families. Please modify ssd1306.h if you know what you are doing. Also please send a pull request if it turns out the library works on other MCU's as well!"
+#error "SSD1306 library was tested only on STM32F0, STM32F1, STM32F3, STM32F4, STM32F7, STM32L0, STM32L1, STM32L4, STM32H7, STM32G0, STM32G4, STM32WB, STM32C0 MCU families. Please modify ssd1306.h if you know what you are doing. Also please send a pull request if it turns out the library works on other MCU's as well!"
 #endif
 
 

--- a/ssd1306/ssd1306_conf_template.h
+++ b/ssd1306/ssd1306_conf_template.h
@@ -17,6 +17,7 @@
 //#define STM32H7
 //#define STM32F7
 //#define STM32G0
+//#define STM32C0
 
 // Choose a bus
 #define SSD1306_USE_I2C


### PR DESCRIPTION
This library has been tested on STM32C071. I have added the microcontroller family into the list of supported families.