### PR TITLE
STM32U5 support

### DIFF
--- a/ssd1306/ssd1306.h
+++ b/ssd1306/ssd1306.h
@@ -46,8 +46,10 @@ _BEGIN_STD_C
 #include "stm32g4xx_hal.h"
 #elif defined(STM32C0)
 #include "stm32c0xx_hal.h"
+#elif defined(STM32U5)
+#include "stm32u5xx_hal.h"
 #else
-#error "SSD1306 library was tested only on STM32F0, STM32F1, STM32F3, STM32F4, STM32F7, STM32L0, STM32L1, STM32L4, STM32H7, STM32G0, STM32G4, STM32WB, STM32C0 MCU families. Please modify ssd1306.h if you know what you are doing. Also please send a pull request if it turns out the library works on other MCU's as well!"
+#error "SSD1306 library was tested only on STM32F0, STM32F1, STM32F3, STM32F4, STM32F7, STM32L0, STM32L1, STM32L4, STM32H7, STM32G0, STM32G4, STM32WB, STM32C0, STM32U5 MCU families. Please modify ssd1306.h if you know what you are doing. Also please send a pull request if it turns out the library works on other MCU's as well!"
 #endif
 
 

--- a/ssd1306/ssd1306_conf_template.h
+++ b/ssd1306/ssd1306_conf_template.h
@@ -18,6 +18,7 @@
 //#define STM32F7
 //#define STM32G0
 //#define STM32C0
+//#define STM32U5
 
 // Choose a bus
 #define SSD1306_USE_I2C


### PR DESCRIPTION
I have added support for the STM32U5. This was tested with a 128x64 SSD1306 display on a NUCLEO-U575ZI-Q.