### PR TITLE
Remove non-portable _ansi.h include

### DIFF
--- a/ssd1306/ssd1306.h
+++ b/ssd1306/ssd1306.h
@@ -8,11 +8,12 @@
 #ifndef __SSD1306_H__
 #define __SSD1306_H__
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include <stddef.h>
 #include <stdint.h>
-#include <_ansi.h>
-
-_BEGIN_STD_C
 
 #include "ssd1306_conf.h"
 
@@ -213,6 +214,8 @@ void ssd1306_WriteCommand(uint8_t byte);
 void ssd1306_WriteData(uint8_t* buffer, size_t buff_size);
 SSD1306_Error_t ssd1306_FillBuffer(uint8_t* buf, uint32_t len);
 
-_END_STD_C
+#ifdef __cplusplus
+}
+#endif
 
 #endif // __SSD1306_H__

--- a/ssd1306/ssd1306_tests.h
+++ b/ssd1306/ssd1306_tests.h
@@ -1,9 +1,9 @@
 #ifndef __SSD1306_TEST_H__
 #define __SSD1306_TEST_H__
 
-#include <_ansi.h>
-
-_BEGIN_STD_C
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 void ssd1306_TestBorder(void);
 void ssd1306_TestFonts1(void);
@@ -19,6 +19,8 @@ void ssd1306_TestArc(void);
 void ssd1306_TestPolyline(void);
 void ssd1306_TestDrawBitmap(void);
 
-_END_STD_C
+#ifdef __cplusplus
+}
+#endif
 
 #endif // __SSD1306_TEST_H__


### PR DESCRIPTION
`#include <_ansi.h>` requires newlib C library (gcc)

I replaced `_BEGIN_STD_C` and `_END_STD_C` with a more generic include guard...